### PR TITLE
修复没有更多数据时的没有回调

### DIFF
--- a/Source/Classes/ElasticRefreshHeader.swift
+++ b/Source/Classes/ElasticRefreshHeader.swift
@@ -20,7 +20,6 @@ open class ElasticRefreshHeader: UIView,RefreshableHeader {
         let adjustFrame = CGRect(x: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: totalHegiht)
         super.init(frame: adjustFrame)
         self.autoresizingMask = .flexibleWidth
-        self.backgroundColor = UIColor.white
         imageView.sizeToFit()
         imageView.frame = CGRect(x: 0, y: 0, width: 16, height: 16)
         textLabel.font = UIFont.systemFont(ofSize: 12)

--- a/Source/Classes/PullToRefresh.swift
+++ b/Source/Classes/PullToRefresh.swift
@@ -206,7 +206,8 @@ public extension UIScrollView{
     }
     public func setFooterNoMoreData(){
         let footer = self.viewWithTag(PullToRefreshKitConst.footerTag) as? RefreshFooterContainer
-        footer?.endRefreshing()
+        footer?.updateToNoMoreData()
+//         footer?.endRefreshing()
     }
     public func resetFooterToDefault(){
         let footer = self.viewWithTag(PullToRefreshKitConst.footerTag) as? RefreshFooterContainer


### PR DESCRIPTION
嗨， 我发现调用 `setFooterNoMoreData` 没有效果，
源码中也没有对改状态进行处理，于是做了修改。

抱歉没有看到， 原来是调用 `endFooterRefreshingWithNoMoreData` 。