### PR TITLE
解决noMoreData状态，点击还能继续加载的bug

### DIFF
--- a/Source/Classes/PullToRefresh.swift
+++ b/Source/Classes/PullToRefresh.swift
@@ -198,7 +198,9 @@ public extension UIScrollView{
     }
     public func beginFooterRefreshing(){
         let footer = self.viewWithTag(PullToRefreshKitConst.footerTag) as? RefreshFooterContainer
-        footer?.beginRefreshing()
+        if footer?.state == .idle {
+            footer?.beginRefreshing()
+        }
     }
     public func endFooterRefreshing(){
         let footer = self.viewWithTag(PullToRefreshKitConst.footerTag) as? RefreshFooterContainer


### PR DESCRIPTION
这里其他状态应该不能继续调用beginRefreshing吧，至少得有一个 不等于 noMoreData的保护吧？
if footer?.state != .noMoreData {
        footer?.beginRefreshing()
}