### PR TITLE
Keep footer at bottom

### DIFF
--- a/Source/Classes/Footer.swift
+++ b/Source/Classes/Footer.swift
@@ -334,7 +334,7 @@ class RefreshFooterContainer:UIView{
         }
     }
     func handleContentSizeChange(_ change: [NSKeyValueChangeKey : Any]?){
-        self.frame = CGRect(x: 0,y: self.attachedScrollView.contentSize.height,width: self.frame.size.width,height: self.frame.size.height)
+        self.frame = CGRect(x: 0,y: max(self.attachedScrollView.contentSize.height, self.attachedScrollView.frame.height),width: self.frame.size.width,height: self.frame.size.height)
     }
 // MARK: - KVO -
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {


### PR DESCRIPTION
As title said, 

Keep footer at bottom no matter what number of items in UITableView or UICollectionView

PullToRefreshKit (0.8.2)